### PR TITLE
Require C extensions for successful build

### DIFF
--- a/giraffez/__init__.py
+++ b/giraffez/__init__.py
@@ -29,7 +29,7 @@ user-friendly and very fast.
 """
 
 __title__ = 'giraffez'
-__version__ = '1.0.2'
+__version__ = '1.0.3'
 __authors__ = ['Christopher Marshall', 'Kyle Travis']
 __license__ = 'Apache 2.0'
 __all__     = ['Export', 'MLoad', 'Load', 'Cmd', 'Config', 'Secret']


### PR DESCRIPTION
This behavior is being changed to improve the user experience when installing giraffez from pip.  Pip provides no way to output information that would indicate which of the C extensions did or did not install correctly so for now it must simply fail or succeed when installing (which produces retroactively the setuptools output).