### PR TITLE
Allow quoting in delimited files, so delimiters in quoted fields can be ignored

### DIFF
--- a/docs/source/command-line.rst
+++ b/docs/source/command-line.rst
@@ -129,7 +129,7 @@ Initiating a load into an existing table can be done like so::
 
     giraffez load source_file.txt database.table_name
 
-The ``load`` command necessitates that a header is present in the source file. The delimiter for the rows of the file is inferred from the content of the header, as well as the names and order of the table's target columns. 
+The ``load`` command necessitates that a header is present in the source file. The delimiter for the rows of the file is inferred from the content of the header, as well as the names and order of the table's target columns.  By default, delimiters within "double quotes" are ignored; use ``--quote-char`` to change the default quote character.
 
 .. _mload-command:
 
@@ -144,7 +144,7 @@ Initiating a load into an existing table can be done like so::
 
     giraffez mload source_file.txt database.table_name
 
-As with ``load``, the ``mload`` command uses the data file's header to determine the columns used in the destination table.
+As with ``load``, the ``mload`` command uses the data file's header to determine the columns used in the destination table.  By default, delimiters within "double quotes" are ignored; use ``--quote-char`` to change the default quote character.
 
 During the process of a load, you may be prompted to drop existing work tables for the target table. giraffez will handle the management of these auxiliary tables for you, but by default you will be prompted for a decision before they are dropped. To automatically answer "yes" for these questions (and drop the auxilliary tables should they already exist), specify the ``-y`` (or ``--drop-all``) flag with the command::
 

--- a/giraffez/commandline.py
+++ b/giraffez/commandline.py
@@ -322,8 +322,6 @@ class FmtCommand(Command):
                 if f.file_type == GIRAFFE_ARCHIVE_FILE:
                     encoder = _encoder.Encoder(columns)
                     processors.append(encoder.unpack_row)
-                else: # text_to_string is handled by the csv parser
-                    pass
                 if args.null:
                     src_null, dst_null = args.null.split(" to ", 1)
                     processors.append(null_handler(src_null))
@@ -413,13 +411,12 @@ class MLoadCommand(Command):
         header = FileReader.read_header(args.input_file)
         if header == GIRAFFE_MAGIC:
             args.encoding = "archive"
+        elif args.delimiter is None:
+            args.delimiter = FileReader.check_delimiter(args.input_file)
 
         if not FileReader.check_length(args.input_file, MLOAD_THRESHOLD):
             show_warning(("USING MLOAD TO INSERT LESS THAN {} ROWS IS NOT RECOMMENDED - USE LOAD "
                 "INSTEAD!").format(MLOAD_THRESHOLD), UserWarning)
-
-        if args.delimiter is None:
-            args.delimiter = FileReader.check_delimiter(args.input_file)
 
         with TeradataMLoad(log_level=args.log_level, config=args.conf, key_file=args.key,
                 dsn=args.dsn) as mload:

--- a/giraffez/mload.py
+++ b/giraffez/mload.py
@@ -311,7 +311,7 @@ class TeradataMLoad(Connection):
             delimiter to be determined from the header of the file. In most
             cases, this behavior is sufficient
         :param str quotechar: The character used to quote fields containing special characters,
-            like the delimiter."
+            like the delimiter.
         :param bool panic: If :code:`True`, when an error is encountered it will be
             raised. Otherwise, the error will be logged and :code:`self.error_count`
             is incremented.

--- a/giraffez/mload.py
+++ b/giraffez/mload.py
@@ -58,7 +58,7 @@ class TeradataMLoad(Connection):
     :param str key_file: Specify an alternate key file to use for configuration decryption
     :param string dsn: Specify a connection name from the configuration file to be
         used, in place of the default.
-    :param bool protect: If authentication with Teradata fails and :code:`protect` is :code:`True`, 
+    :param bool protect: If authentication with Teradata fails and :code:`protect` is :code:`True`,
         locks the connection used in the configuration file. This can be unlocked using the
         command :code:`giraffez config --unlock <connection>`, changing the connection password,
         or via the :meth:`~giraffez.config.Config.unlock_connection` method.
@@ -66,7 +66,7 @@ class TeradataMLoad(Connection):
     :raises `giraffez.errors.TeradataError`: if the connection cannot be established
 
     If the target table is currently under an MLoad lock (such as if the
-    previous operation failed), a :code:`release mload` statement will be 
+    previous operation failed), a :code:`release mload` statement will be
     executed on the table, and the load job will be re-attempted.
 
     Meant to be used, where possible, with python's :code:`with` context handler
@@ -193,7 +193,7 @@ class TeradataMLoad(Connection):
 
     def cleanup(self):
         """
-        Drops any existing work tables, as returned by 
+        Drops any existing work tables, as returned by
         :meth:`~giraffez.mload.TeradataMLoad.tables`.
 
         :raises `giraffez.errors.TeradataError`: if a Teradata error ocurred
@@ -223,7 +223,7 @@ class TeradataMLoad(Connection):
             order. The value must be a :code:`list` of names in the order that
             the fields of data will be presented in each row.
 
-            Raises :class:`~giraffez.errors.GiraffeError` if :code:`field_names` 
+            Raises :class:`~giraffez.errors.GiraffeError` if :code:`field_names`
             is not a :code:`list`.
 
             Raises :class:`~giraffez.errors.GiraffeError` if the target table
@@ -246,7 +246,7 @@ class TeradataMLoad(Connection):
         The encoding of the file being loaded.
 
         :getter: Returns the name of the encoding being used.
-        :setter: Set the encoding of the input file if not specified to the 
+        :setter: Set the encoding of the input file if not specified to the
             constructor of the instance. Accepted values are :code:`'text'`
             or :code:`'archive'`.
 
@@ -286,7 +286,7 @@ class TeradataMLoad(Connection):
             self._handle_error()
         return exit_code
 
-    def from_file(self, filename, table=None, null=DEFAULT_NULL, delimiter=None, panic=True):
+    def from_file(self, filename, table=None, null=DEFAULT_NULL, delimiter=None, panic=True, quotechar='"'):
         """
         Load from a file into the target table, handling each step of the
         load process.
@@ -298,7 +298,7 @@ class TeradataMLoad(Connection):
 
         It is not necessary to set the columns in use prior to loading from a file.
         In the case of a text file, the header is used to determine column names
-        and their order. Valid delimiters include '|', ',', and '\\t' (tab). When 
+        and their order. Valid delimiters include '|', ',', and '\\t' (tab). When
         loading an archive file, the column information is decoded alongside the data.
 
         :param str filename: The location of the file to be loaded
@@ -310,6 +310,8 @@ class TeradataMLoad(Connection):
             separated by this delimiter. Defaults to :code:`None`, which causes the
             delimiter to be determined from the header of the file. In most
             cases, this behavior is sufficient
+        :param str quotechar: The character used to quote fields containing special characters,
+            like the delimiter."
         :param bool panic: If :code:`True`, when an error is encountered it will be
             raised. Otherwise, the error will be logged and :code:`self.error_count`
             is incremented.
@@ -325,12 +327,12 @@ class TeradataMLoad(Connection):
                 raise GiraffeError("Table must be set or specified to load a file.")
             self.table = table
 
-        with Reader(filename, delimiter=delimiter) as f:
+        with Reader(filename, delimiter=delimiter, quotechar=quotechar) as f:
             self.columns = f.field_names()
 
             if f.file_type == DELIMITED_TEXT_FILE:
                 self.processor = pipeline([
-                    text_to_strings(f.delimiter),
+                    #text_to_strings(f.delimiter),
                     null_handler(null),
                     python_to_teradata(self.columns, self.allow_precision_loss)
                 ])
@@ -426,7 +428,7 @@ class TeradataMLoad(Connection):
             was not given to the constructor of the
             :class:`~giraffez.mload.TeradataMLoad` instance or
             :meth:`~giraffez.mload.TeradataMLoad.from_file`. The value given
-            must include all qualifiers such as database name. 
+            must include all qualifiers such as database name.
 
             Raises :class:`~giraffez.errors.GiraffeError` if the MLoad connection has
             already been initiated, or the :class:`~giraffez.cmd.TeradataCmd` connection cannot

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -22,7 +22,7 @@ class TestLoad(object):
         mock_columns = mocker.patch("giraffez.Cmd.get_columns")
 
         mock_columns.return_value = columns
-        
+
         with open(tmpfiles.load_file, 'w') as f:
             f.write("|".join(["col1", "col2", "col3"]))
             f.write("\n")
@@ -34,6 +34,61 @@ class TestLoad(object):
         with giraffez.Load() as load:
             result = load.from_file("db1.test", tmpfiles.load_file, delimiter="|")
         assert result.get('count') == 5000
+
+    def test_load_from_file_quoted(self, mocker, tmpfiles):
+        mock_connect = mocker.patch("giraffez.Cmd._connect")
+        mock_execute = mocker.patch("giraffez.Cmd._execute")
+
+        columns = Columns([
+            ("col1", VARCHAR_NN, 50, 0, 0),
+            ("col2", VARCHAR_N, 50, 0, 0),
+            ("col3", VARCHAR_N, 50, 0, 0),
+        ])
+
+        mock_columns = mocker.patch("giraffez.Cmd.get_columns")
+
+        mock_columns.return_value = columns
+
+        with open(tmpfiles.load_file, 'w') as f:
+            f.write("|".join(["col1", "col2", "col3"]))
+            f.write("\n")
+            rows = []
+            for i in range(4999):
+                rows.append("|".join(["value1", "value2", "value3"]))
+            rows.append("|".join(["value1",'"value2|withpipe"', "value3"]))
+            f.write("\n".join(rows))
+
+        with giraffez.Load() as load:
+            result = load.from_file("db1.test", tmpfiles.load_file, delimiter="|")
+        assert result.get('count') == 5000
+
+    def test_load_from_file_single_quoted(self, mocker, tmpfiles):
+        mock_connect = mocker.patch("giraffez.Cmd._connect")
+        mock_execute = mocker.patch("giraffez.Cmd._execute")
+
+        columns = Columns([
+            ("col1", VARCHAR_NN, 50, 0, 0),
+            ("col2", VARCHAR_N, 50, 0, 0),
+            ("col3", VARCHAR_N, 50, 0, 0),
+        ])
+
+        mock_columns = mocker.patch("giraffez.Cmd.get_columns")
+
+        mock_columns.return_value = columns
+
+        with open(tmpfiles.load_file, 'w') as f:
+            f.write("|".join(["col1", "col2", "col3"]))
+            f.write("\n")
+            rows = []
+            for i in range(4999):
+                rows.append("|".join(["value1", "value2", "value3"]))
+            rows.append("|".join(["value1","'value2|withpipe'", "value3"]))
+            f.write("\n".join(rows))
+
+        with giraffez.Load() as load:
+            result = load.from_file("db1.test", tmpfiles.load_file, delimiter="|", quotechar="'")
+        assert result.get('count') == 5000
+
 
     def test_load_from_file_error(self, mocker, tmpfiles):
         mock_connect = mocker.patch("giraffez.Cmd._connect")
@@ -48,7 +103,7 @@ class TestLoad(object):
         mock_columns = mocker.patch("giraffez.Cmd.get_columns")
 
         mock_columns.return_value = columns
-        
+
         with open(tmpfiles.load_file, 'w') as f:
             f.write("|".join(["col1", "col2", "col3"]))
             f.write("\n")
@@ -71,7 +126,7 @@ class TestLoad(object):
         mock_columns = mocker.patch("giraffez.Cmd.get_columns")
 
         mock_columns.return_value = columns
-        
+
         with open(tmpfiles.load_file, 'w') as f:
             f.write("|".join(["col1", "col2", "col3"]))
             f.write("\n")

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -90,6 +90,34 @@ class TestLoad(object):
         assert result.get('count') == 5000
 
 
+    def test_load_from_file_nonstandard_quote(self, mocker, tmpfiles):
+        mock_connect = mocker.patch("giraffez.Cmd._connect")
+        mock_execute = mocker.patch("giraffez.Cmd._execute")
+
+        columns = Columns([
+            ("col1", VARCHAR_NN, 50, 0, 0),
+            ("col2", VARCHAR_N, 50, 0, 0),
+            ("col3", VARCHAR_N, 50, 0, 0),
+        ])
+
+        mock_columns = mocker.patch("giraffez.Cmd.get_columns")
+
+        mock_columns.return_value = columns
+
+        with open(tmpfiles.load_file, 'w') as f:
+            f.write("|".join(["col1", "col2", "col3"]))
+            f.write("\n")
+            rows = []
+            for i in range(4999):
+                rows.append("|".join(["value1", "value2", "value3"]))
+            rows.append("|".join(['va"lue1','$value2|withpipe"and"quote$', "value3"]))
+            f.write("\n".join(rows))
+
+        with giraffez.Load() as load:
+            result = load.from_file("db1.test", tmpfiles.load_file, delimiter="|", quotechar="$")
+        assert result.get('count') == 5000
+
+        
     def test_load_from_file_error(self, mocker, tmpfiles):
         mock_connect = mocker.patch("giraffez.Cmd._connect")
         mock_execute = mocker.patch("giraffez.Cmd._execute")


### PR DESCRIPTION

Use the csv library to parse data files given to load and mload.  This allows fields to be quoted, which means they can now contain the delimiter without breaking the parse.

Addresses capitalone/giraffez#14.