### PR TITLE
Fix multiple Cmd bugs, disable parallel build

### DIFF
--- a/giraffez/__init__.py
+++ b/giraffez/__init__.py
@@ -29,7 +29,7 @@ user-friendly and very fast.
 """
 
 __title__ = 'giraffez'
-__version__ = '1.1.5'
+__version__ = '1.1.6'
 __authors__ = ['Christopher Marshall', 'Kyle Travis']
 __license__ = 'Apache 2.0'
 __all__     = ['Export', 'MLoad', 'Load', 'Cmd', 'Config', 'Secret']

--- a/giraffez/encoder/types.h
+++ b/giraffez/encoder/types.h
@@ -21,6 +21,7 @@
 extern "C" {
 #endif
 
+#include <Python.h>
 #include <stddef.h>
 #if defined(WIN32) || defined(WIN64)
 #include <pstdint.h>

--- a/setup.py
+++ b/setup.py
@@ -330,7 +330,9 @@ class BuildExt(build_ext):
     cache = {}
 
     def run(self):
-        self.parallel = multiprocessing.cpu_count()
+        # Disabling parallel build for now. It causes issues on multiple
+        # platforms with concurrent file access causing odd build errors
+        #self.parallel = multiprocessing.cpu_count()
         build_ext.run(self)
 
     def get_inplace_path(self, ext_name):


### PR DESCRIPTION
In `giraffez/cli/cmdobject.c` the session was getting renewed over and over again causing it to be much slower than normal and also to eventually fail with something like 'CLIv2 init request failed'.  This was remedied by ensuring that fetch_record did not set the dbcarea in a way that sets up a new session internally with CLIv2.  The other issue was running multiple Cmd instances in a single script.  This bug was introduced when calling `Cmd_close` also within the dealloc function.  This was wrong because it ran the CLIv2 function for cleanup which apparently uses global variables to store some data (like buffers or something like that).

The other issue was with building on >= Python 3.5 getting strange errors about "truncated files" or just hanging forever on Windows.  The issue was identified to be the parallel option being set when compiling.