### PR TITLE
update commandline.py to decode binary string

### DIFF
--- a/giraffez/commandline.py
+++ b/giraffez/commandline.py
@@ -76,7 +76,7 @@ class CmdCommand(Command):
         if " " not in args.query:
             if file_exists(args.query):
                 file_name = args.query
-                args.query = FileReader.read_all(file_name)
+                args.query = FileReader.read_all(file_name).decode('ascii')
         start_time = time.time()
         with TeradataCmd(log_level=args.log_level, config=args.conf, key_file=args.key,
                 dsn=args.dsn) as cmd:


### PR DESCRIPTION
currently running giraffez cmd "example.sql" fails because it passes a binary string to the parse_arguments method which results in an error at the line statement += c.lower()