### PR TITLE
remove handling head argument from first with stmt

### DIFF
--- a/giraffez/commandline.py
+++ b/giraffez/commandline.py
@@ -315,12 +315,7 @@ class FmtCommand(Command):
                     pass
                 log.info("Lines: ", i)
                 return
-            elif args.head:
-                for i, line in enumerate(f, 1):
-                    if args.head < i:
-                        break
-                    sys.stdout.write(line)
-                return
+            
         with Reader(args.input_file) as f:
             processor = identity
             filter_func = identity


### PR DESCRIPTION
We had this code written in the first with clause:
```
elif args.head:
                for i, line in enumerate(f, 1):
                    if args.head < i:
                        break
                    sys.stdout.write(line)
                return
```

I was running this and getting this error:
```
$> giraffez fmt outie.gd --head=10
Traceback (most recent call last):
  File "/home/ec2-user/.conda/envs/life_events/bin/giraffez", line 11, in <module>
    sys.exit(main())
  File "/home/ec2-user/.conda/envs/life_events/lib/python3.6/site-packages/giraffez/__main__.py", line 25, in main
    MainCommand().run()
  File "/home/ec2-user/.conda/envs/life_events/lib/python3.6/site-packages/giraffez/core.py", line 80, in run
    args.run(args)
  File "/home/ec2-user/.conda/envs/life_events/lib/python3.6/site-packages/giraffez/utils.py", line 145, in wrapper
    result = f(*args, **kwds)
  File "/home/ec2-user/.conda/envs/life_events/lib/python3.6/site-packages/giraffez/commandline.py", line 322, in run
    sys.stdout.write(line)
TypeError: write() argument must be str, not bytes
```

And realized that we were handling `--head` in two different places, once with a plain `sys.stdout.write` and once with more nuance around the process and filterfunction, the former of which handles reading the bytes into string.