### PR TITLE
Add activity count to execute results

### DIFF
--- a/giraffez/_teradatamodule.c
+++ b/giraffez/_teradatamodule.c
@@ -95,6 +95,16 @@ static PyObject* Cmd_columns(Cmd *self, PyObject *args, PyObject *kwargs) {
     return giraffez_columns_to_pyobject(self->encoder->Columns);
 }
 
+static PyObject* Cmd_rowcount(Cmd *self, PyObject *args, PyObject *kwargs) {
+    PyObject *debug = NULL;
+    static char *kwlist[] = {"debug", NULL};
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|O", kwlist, &debug)) {
+        return NULL;
+    }
+
+    return PyLong_FromLong(self->conn->rowcount);
+}
+
 static PyObject* Cmd_execute(Cmd *self, PyObject *args, PyObject *kwargs) {
     char *command = NULL;
     int prepare_only = 0;
@@ -160,6 +170,7 @@ static PyObject* Cmd_set_encoding(Cmd *self, PyObject *args) {
 static PyMethodDef Cmd_methods[] = {
     {"close", (PyCFunction)Cmd_close, METH_NOARGS, ""},
     {"columns", (PyCFunction)Cmd_columns, METH_VARARGS|METH_KEYWORDS, ""},
+    {"rowcount", (PyCFunction)Cmd_rowcount, METH_VARARGS|METH_KEYWORDS, ""},
     {"execute", (PyCFunction)Cmd_execute, METH_VARARGS|METH_KEYWORDS, ""},
     {"fetchone", (PyCFunction)Cmd_fetchone, METH_NOARGS, ""},
     {"set_encoding", (PyCFunction)Cmd_set_encoding, METH_VARARGS, ""},

--- a/giraffez/_teradatamodule.c
+++ b/giraffez/_teradatamodule.c
@@ -95,13 +95,7 @@ static PyObject* Cmd_columns(Cmd *self, PyObject *args, PyObject *kwargs) {
     return giraffez_columns_to_pyobject(self->encoder->Columns);
 }
 
-static PyObject* Cmd_rowcount(Cmd *self, PyObject *args, PyObject *kwargs) {
-    PyObject *debug = NULL;
-    static char *kwlist[] = {"debug", NULL};
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|O", kwlist, &debug)) {
-        return NULL;
-    }
-
+static PyObject* Cmd_rowcount(Cmd *self) {
     return PyLong_FromLong(self->conn->rowcount);
 }
 
@@ -170,7 +164,7 @@ static PyObject* Cmd_set_encoding(Cmd *self, PyObject *args) {
 static PyMethodDef Cmd_methods[] = {
     {"close", (PyCFunction)Cmd_close, METH_NOARGS, ""},
     {"columns", (PyCFunction)Cmd_columns, METH_VARARGS|METH_KEYWORDS, ""},
-    {"rowcount", (PyCFunction)Cmd_rowcount, METH_VARARGS|METH_KEYWORDS, ""},
+    {"rowcount", (PyCFunction)Cmd_rowcount, METH_NOARGS, ""},
     {"execute", (PyCFunction)Cmd_execute, METH_VARARGS|METH_KEYWORDS, ""},
     {"fetchone", (PyCFunction)Cmd_fetchone, METH_NOARGS, ""},
     {"set_encoding", (PyCFunction)Cmd_set_encoding, METH_VARARGS, ""},

--- a/giraffez/cmd.py
+++ b/giraffez/cmd.py
@@ -83,6 +83,10 @@ class Cursor(object):
         if self.prepare_only:
             self.columns = self._columns()
 
+    @property
+    def rowcount(self):
+        return self.conn.rowcount()
+
     def _columns(self):
         columns = self.conn.columns()
         log.debug("Debug[2]", repr(self.conn.columns(debug=True)))

--- a/giraffez/src/teradata.h
+++ b/giraffez/src/teradata.h
@@ -50,6 +50,7 @@ typedef struct TeradataConnection {
     Int32 result;
     int connected;
     int request_status;
+    int rowcount;
 } TeradataConnection;
 
 typedef struct TeradataErr {

--- a/giraffez/src/teradata.h
+++ b/giraffez/src/teradata.h
@@ -50,7 +50,22 @@ typedef struct TeradataConnection {
     Int32 result;
     int connected;
     int request_status;
-    int rowcount;
+
+    /* TODO: What type to use for 'rowcount'?
+     *
+     * The Teradata API returns a 32 byte unsigned integer for this value.
+     * That means we at least want to support up to UINT32_MAX. However,
+     * it'd also be nice to allow for -1 as an indicator for any errors
+     * or that the value hasn't been updated yet.
+     *
+     * I see a few options:
+     *  long - Should be big enough but lacks potential cross-platform
+     *          sizing consistency
+     *  ssize_t - Same idea as long, but again could fail on 32-bit systems?
+     *  int64_t - Explicitly define that this field needs to be large
+     *              to support UINT32_MAX _and_ negative values
+     */
+    long rowcount;
 } TeradataConnection;
 
 typedef struct TeradataErr {


### PR DESCRIPTION
This is my first proof of concept to resolve issue #54. Pulling the value out of the PclSUCCESS parcel was easy enough, but I saw a few different options for propagating the `rowcount` back up to a Cursor object. I initially looked at using the return value from [teradata_execute](https://github.com/theandrew168/giraffez/blob/add_activity_count_to_execute_results/giraffez/src/teradata.c#L256), but that would have required a few more changes to the codebase (as well as changing the existing usage of that function).

The changes in this PR involve adding a `rowcount` field to the [TeradataConnection](https://github.com/theandrew168/giraffez/blob/add_activity_count_to_execute_results/giraffez/src/teradata.h#L53) struct. Then, if a PclSUCCESS is found while reading parcels, pull out its ActivityCount and throw it into that field. Lastly, a property was added to the [Cursor](https://github.com/theandrew168/giraffez/blob/add_activity_count_to_execute_results/giraffez/cmd.py#L87) object for reading this value.

My primary concern with this implementation is that `rowcount` doesn't seem to really belong in the `TeradataConnection` struct. Had there existed some sort of `TeradataCursor` struct, I would have leaned toward putting the value in there instead. However, from what I was able to discern, the passing of database state between [Cmd.execute](https://github.com/theandrew168/giraffez/blob/add_activity_count_to_execute_results/giraffez/src/teradata.h#L53) and the [Cursor](https://github.com/theandrew168/giraffez/blob/add_activity_count_to_execute_results/giraffez/cmd.py#L44) it returns is contained within the [conn](https://github.com/theandrew168/giraffez/blob/add_activity_count_to_execute_results/giraffez/cmd.py#L63) parameter. Additionally (and I could be wrong), it looks like this `conn` parameter is actually an instance of the `Cmd` object defined [here](https://github.com/theandrew168/giraffez/blob/add_activity_count_to_execute_results/giraffez/_teradatamodule.c#L170). Another downside of having the field located in `TeradataConnection` is that it'd get overwritten by every subsequent database action.

Do you suppose it'd be more ideal to add the `rowcount` field to something like [TeradataEncoder](https://github.com/theandrew168/giraffez/blob/add_activity_count_to_execute_results/giraffez/src/encoder.h#L53) since its "context" is more closely related to each individual SQL command? Do you suppose that some completely different scheme that uses the return value from [teradata_execute](https://github.com/theandrew168/giraffez/blob/add_activity_count_to_execute_results/giraffez/src/teradata.c#L256) would better fit this problem?

Please let me know what you think!